### PR TITLE
feat(validation) : add POST and DELETE endpoint methods

### DIFF
--- a/src/protocol/validation.ts
+++ b/src/protocol/validation.ts
@@ -97,6 +97,22 @@ export class Validation extends BaseValidation {
     });
   }
 
+  async postEndpoint(path: `/${string}`, body: any) {
+    return await this.pipe.send(this.resource.operatorAddress, {
+      path,
+      method: PipeMethod.POST,
+      body,
+    });
+  }
+
+  async deleteEndpoint(path: `/${string}`, body: any) {
+    return await this.pipe.send(this.resource.operatorAddress, {
+      path,
+      method: PipeMethod.DELETE,
+      body,
+    });
+  }
+
   getTestCollections(): PreparedCollection[] {
     return this.testCollections;
   }

--- a/src/utils/testCollectionManager.ts
+++ b/src/utils/testCollectionManager.ts
@@ -35,7 +35,7 @@ export async function prepareTestCollection(
     { name: "label", type: "String" },
   ];
 
-  await validation.callEndpoint("/collection", {
+  await validation.postEndpoint("/collection", {
     id: resource.id,
     pc: resource.protocol,
     name,
@@ -56,7 +56,7 @@ export async function prepareTestCollection(
     });
   }
 
-  await validation.callEndpoint("/data", {
+  await validation.postEndpoint("/data", {
     id: resource.id,
     pc: resource.protocol,
     collection: name,
@@ -72,7 +72,7 @@ export async function cleanupTestCollection(
   resource: Resource,
   name: string
 ) {
-  await validation.callEndpoint("/collection", {
+  await validation.deleteEndpoint("/collection", {
     id: resource.id,
     pc: resource.protocol,
     name,


### PR DESCRIPTION
This update adds support for proper HTTP methods in the Validation class:

- Added postEndpoint method to handle POST requests for creating collections and inserting data
- Added deleteEndpoint method to handle DELETE requests for collection cleanup
- Maintains consistent interface with existing callEndpoint method
- Fixes type errors in testCollectionManager.ts by providing required methods

These changes ensure that collection management operations use the correct HTTP methods when communicating with the provider.